### PR TITLE
Add new language defaults

### DIFF
--- a/fileformats/init.go
+++ b/fileformats/init.go
@@ -5,4 +5,7 @@ import (
 	_ "editorconfig-guesser/fileformats/generic"
 	_ "editorconfig-guesser/fileformats/gnumake"
 	_ "editorconfig-guesser/fileformats/go"
+	_ "editorconfig-guesser/fileformats/java"
+	_ "editorconfig-guesser/fileformats/ruby"
+	_ "editorconfig-guesser/fileformats/rust"
 )

--- a/fileformats/java/ectemplate
+++ b/fileformats/java/ectemplate
@@ -1,0 +1,2 @@
+indent_style = space
+indent_size = 4

--- a/fileformats/java/java.go
+++ b/fileformats/java/java.go
@@ -1,0 +1,23 @@
+package java
+
+import (
+	ecg "editorconfig-guesser"
+	_ "embed"
+)
+
+var (
+	//go:embed "ectemplate"
+	ectemplate []byte
+)
+
+func init() {
+	ecg.Register(func() ecg.FileFormat {
+		return ecg.NewPresence(
+			"Java",
+			[]string{
+				"*.java",
+			},
+			ectemplate,
+		)
+	})
+}

--- a/fileformats/ruby/ectemplate
+++ b/fileformats/ruby/ectemplate
@@ -1,0 +1,2 @@
+indent_style = space
+indent_size = 2

--- a/fileformats/ruby/ruby.go
+++ b/fileformats/ruby/ruby.go
@@ -1,0 +1,25 @@
+package ruby
+
+import (
+	ecg "editorconfig-guesser"
+	_ "embed"
+)
+
+var (
+	//go:embed "ectemplate"
+	ectemplate []byte
+)
+
+func init() {
+	ecg.Register(func() ecg.FileFormat {
+		return ecg.NewPresence(
+			"Ruby",
+			[]string{
+				"*.rb",
+				"Rakefile",
+				"Gemfile",
+			},
+			ectemplate,
+		)
+	})
+}

--- a/fileformats/rust/ectemplate
+++ b/fileformats/rust/ectemplate
@@ -1,0 +1,2 @@
+indent_style = space
+indent_size = 4

--- a/fileformats/rust/rust.go
+++ b/fileformats/rust/rust.go
@@ -1,0 +1,24 @@
+package rust
+
+import (
+	ecg "editorconfig-guesser"
+	_ "embed"
+)
+
+var (
+	//go:embed "ectemplate"
+	ectemplate []byte
+)
+
+func init() {
+	ecg.Register(func() ecg.FileFormat {
+		return ecg.NewPresence(
+			"Rust",
+			[]string{
+				"Cargo.toml",
+				"*.rs",
+			},
+			ectemplate,
+		)
+	})
+}

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,9 @@ Currently:
 * `*.py`  - [Generic](fileformats/generic)
 * `*.go;go.mod;go.sum` - [Custom](fileformats/go)
 * `Makefile;*.mak` - [Custom](fileformats/gnumake)
+* `*.java` - [Custom](fileformats/java)
+* `*.rb;Rakefile;Gemfile` - [Custom](fileformats/ruby)
+* `Cargo.toml;*.rs` - [Custom](fileformats/rust)
 
 Happy to accept PRs for more.
 


### PR DESCRIPTION
## Summary
- add Java, Ruby and Rust file formats with default indentation styles
- update registry to include new file formats
- document newly supported languages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68540dbe3a0c832fbb5b568a71bc1db1