### PR TITLE
Fix cache action version

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -24,6 +24,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest


### PR DESCRIPTION
## Summary
- bump golangci-lint action to v8 to avoid using old cache logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854ddb91ea0832f8fb00e87f83e599e